### PR TITLE
perf: Preconvert MD to HTML on extension start

### DIFF
--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -11,6 +11,7 @@ interface TutorialData {
 
 interface SectionStep {
   doc: string;
+  docHTML?: string;
   code: string;
 }
 
@@ -21,16 +22,19 @@ interface Section {
 }
 
 class QuickstartSection {
-  title: string;
-  description: string;
-  _steps: SectionStep[];
-  currentStep: number;
+  public title: string;
+  public context: vscode.ExtensionContext;
+  public description: string;
+  public currentStep: number;
+  private _steps: SectionStep[];
   private _done = false;
 
-  constructor(section: Section) {
+  constructor(section: Section, context: vscode.ExtensionContext ) {
+    this.context = context;
     this.title = section.title;
     this.description = section.description;
     this._steps = section.steps;
+    this._convertStepMarkdown();
     this.currentStep = 0;
     return this;
   }
@@ -38,7 +42,7 @@ class QuickstartSection {
   nextStep() {
     if (this.currentStep + 1 < this._steps.length) {
       this.currentStep++;
-    } 
+    }
     if (this.currentStep >= this._steps.length - 1) {
       this._done = true;
     }
@@ -46,6 +50,12 @@ class QuickstartSection {
 
   doc() {
     return this._steps[this.currentStep].doc;
+  }
+
+  docHTML() {
+    const html = this._steps[this.currentStep].docHTML;
+
+    return html ? html : "";
   }
 
   code() {
@@ -59,6 +69,13 @@ class QuickstartSection {
 
   isDone() {
     return this._done;
+  }
+
+  private _convertStepMarkdown() {
+    this._steps.forEach((step) => {
+    const tutorialPath = path.join(this.context.extensionPath, step.doc);
+      step.docHTML = generateHTMLfromMD(tutorialPath);
+    });
   }
 }
 
@@ -75,7 +92,7 @@ export default class Quickstart {
   constructor(metadata: TutorialData, context: vscode.ExtensionContext) {
     this.metadata = metadata;
     this.sections = this.metadata.sections.map((section) => {
-      return new QuickstartSection(section);
+      return new QuickstartSection(section, context);
     });
     this.context = context;
     this.currentSection = this.sections[0];
@@ -93,7 +110,7 @@ export default class Quickstart {
     });
 
     this.openCodePanel(this.currentSection.code());
-    this.openDocPanel(this.currentSection.title, this.currentSection.doc());
+    this.openDocPanel(this.currentSection.title, this.currentSection.docHTML());
   }
 
   openNextStep() {
@@ -126,8 +143,10 @@ export default class Quickstart {
       const filePath: string = this.editor.document.uri.fsPath;
 
       // watcher to automatically run next step when current file runs
-      const { successFilePath, errorFilePath } =
-        this._initializeFileWatcher(filePath, callback);
+      const { successFilePath, errorFilePath } = this._initializeFileWatcher(
+        filePath,
+        callback
+      );
       this._runCode(filePath, successFilePath, errorFilePath);
 
       this.terminal.show();
@@ -165,17 +184,15 @@ export default class Quickstart {
 
   // HELPERS
 
-  openDocPanel(title: string, docPath: string) {
+  openDocPanel(title: string, docContent: string) {
     if (!this.panel) {
       this._initializePanel();
     }
 
-    const tutorialPath = path.join(this.context.extensionPath, docPath);
-
     // nullcheck to make typescript happy
     if (this.panel) {
       this.panel.title = title;
-      this.panel.webview.html = generateHTMLfromMD(tutorialPath);
+      this.panel.webview.html = docContent;
     }
   }
 


### PR DESCRIPTION
There were times where the process of converting the .md files to HTML in order to display in the vscode webview would be noticeably slower to load then the corresponding .py file it was paired with. These changes make the `QuickstartSection` class convert the files to HTML when the app is first loaded instead of on demand.