### PR TITLE
Optional code for step

### DIFF
--- a/src/quickstartMetadata.json
+++ b/src/quickstartMetadata.json
@@ -24,7 +24,8 @@
           "html": "zenmlQuickstart/sections/basicPipeline/connectToZenmlCloud.html"
         },
         {
-          "doc": "zenmlQuickstart/sections/basicPipeline/finish.md"
+          "doc": "zenmlQuickstart/sections/basicPipeline/finish.md",
+          "code": "zenmlQuickstart/sections/basicPipeline/code2.py"
         }
       ]
     },

--- a/src/quickstartSection.ts
+++ b/src/quickstartSection.ts
@@ -10,7 +10,7 @@ export interface TutorialData {
 interface SectionStep {
   doc: string;
   docHTML?: string;
-  code: string;
+  code?: string;
   html?: string;
 }
 


### PR DESCRIPTION
This branch makes the `code` field for each section step in the `quickstartMetadata.json` optional. If the field is left blank the code editor will close until switching to a current step that has a code field.